### PR TITLE
donttest -> dontrun

### DIFF
--- a/R/adapt_particles.R
+++ b/R/adapt_particles.R
@@ -28,7 +28,7 @@
 #' max_time <- max(vapply(example_obs[obs_states], function(x) {
 #'   max(x[["time"]])
 #' }, 0))
-#' \donttest{
+#' \dontrun{
 #'   adapted <- adapt_particles(example_bi, nsamples = 128, end_time = max_time)
 #' }
 #' @export

--- a/R/adapt_proposal.R
+++ b/R/adapt_proposal.R
@@ -40,7 +40,7 @@
 #'   max(x[["time"]])
 #' }, 0))
 #' # adapt to acceptance rate between 0.1 and 0.5
-#' \donttest{
+#' \dontrun{
 #'   adapted <- adapt_proposal(example_bi,
 #'     nsamples = 100, end_time = max_time,
 #'     min = 0.1, max = 0.5, nparticles = 256, correlations = TRUE

--- a/man/adapt_particles.Rd
+++ b/man/adapt_particles.Rd
@@ -49,7 +49,7 @@ obs_states <- rbi::var_names(example_model, type = "obs")
 max_time <- max(vapply(example_obs[obs_states], function(x) {
   max(x[["time"]])
 }, 0))
-\donttest{
+\dontrun{
   adapted <- adapt_particles(example_bi, nsamples = 128, end_time = max_time)
 }
 }

--- a/man/adapt_proposal.Rd
+++ b/man/adapt_proposal.Rd
@@ -71,7 +71,7 @@ max_time <- max(vapply(example_obs[obs_states], function(x) {
   max(x[["time"]])
 }, 0))
 # adapt to acceptance rate between 0.1 and 0.5
-\donttest{
+\dontrun{
   adapted <- adapt_proposal(example_bi,
     nsamples = 100, end_time = max_time,
     min = 0.1, max = 0.5, nparticles = 256, correlations = TRUE


### PR DESCRIPTION
to fix error in CRAN log:

```
* checking examples with --run-donttest ... ERROR
Running examples in ‘rbi.helpers-Ex.R’ failed
The error most likely occurred in:

> ### Name: adapt_particles
> ### Title: Adapt the number of particles
> ### Aliases: adapt_particles
> 
> ### ** Examples
> 
> example_obs <- bi_read(system.file(package="rbi", "example_dataset.nc"))
> example_model <- bi_model(system.file(package="rbi", "PZ.bi"))
> example_bi <- libbi(model = example_model, obs = example_obs)
> obs_states <- var_names(example_model, type = "obs")
> max_time <- max(vapply(example_obs[obs_states], function(x) { max(x[["time"]])}, 0))
> ## No test: 
> adapted <- adapt_particles(example_bi, nsamples = 128, end_time = max_time)
Mon Aug 14 13:58:15 2023 Adapting the number of particles
Mon Aug 14 13:58:15 2023 Initial trial run
Error in locate_libbi(x$path_to_libbi) : 
  Could not find libbi executable at '/libbi'
Calls: adapt_particles ... <Anonymous> -> sample.libbi -> run.libbi -> locate_libbi
Execution halted
* checking for unstated dependencies in ‘tests’ ... OK
* checking tests ...
  Running ‘testthat.R’
 OK
* checking for unstated dependencies in vignettes ... OK
* checking package vignettes in ‘inst/doc’ ... OK
* checking re-building of vignette outputs ... [12s/12s] OK
* checking PDF version of manual ... OK
* checking for non-standard things in the check directory ... OK
* checking for detritus in the temp directory ... OK
* checking for new files in some other directories ... OK
* DONE

Status: 1 ERROR
See
  ‘/data/blackswan/ripley/R/packages/tests-devel/rbi.helpers.Rcheck/00check.log’
for details.
```